### PR TITLE
setup.py flags --clang and --omp_target to build with clang and OpenMP target offload

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -13,9 +13,36 @@ if(FBGEMM_CPU_ONLY)
   message("Building for CPU-only")
 endif()
 
+option(FBGEMM_LLVM_DIR "Location of LLVM Installation Direction when building with clang compiler")
+option(FBGEMM_OMP_TARGET "Build fbgemm_gpu using clang OpenMP target offload" OFF)
+if(FBGEMM_LLVM_DIR)
+  if(NOT EXISTS ${FBGEMM_LLVM_DIR})
+    message(FATAL_ERROR "LLVM installation does not exist:${FBGEMM_LLVM_DIR}")
+  endif()
+  if(FBGEMM_OMP_TARGET)
+    message("Building for clang OpenMP Target offload")
+  else()
+    if(FBGEMM_CPU_ONLY)
+      message("Building for CPU-only with clang")
+    else()
+      message("Building for clang cuda (not nvcc)")
+    endif()
+  endif()
+  set(CMAKE_CUDA_COMPILER ${CMAKE_CXX_COMPILER})
+else()
+  # Using nvidia nvcc compiler
+  if(FBGEMM_OMP_TARGET)
+      message(FATAL_ERROR "FBGEMM_OMP_TARGET requires clang compiler")
+  endif()
+  if(NOT FBGEMM_CPU_ONLY)
+    message("Building for cuda with nvcc")
+  endif()
+endif()
+
 message("${message_line}")
 
-if(FBGEMM_CPU_ONLY)
+if(FBGEMM_CPU_ONLY OR FBGEMM_LLVM_DIR)
+  # Some cmake CUDA language customizations fail for clang
   project(
     fbgemm_gpu
     VERSION 0.0.1
@@ -29,6 +56,35 @@ endif()
 
 find_package(Torch REQUIRED)
 find_package(PythonExtensions REQUIRED)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  string(FIND ${CMAKE_CUDA_FLAGS} ",code=sm_" codeloc)
+  if(codeloc)
+    math(EXPR _oastart "${codeloc} + 6")
+    string(SUBSTRING ${CMAKE_CUDA_FLAGS} ${_oastart} 5 OARCH)
+    set(TRIPLE "nvptx64-nvidia-cuda")
+  else()
+    # FIXME: ThIS LIKELY WONT BE THE WAY TO GET AMDGCN OARCH
+    string(FIND ${CMAKE_CUDA_FLAGS} ",code=gfx" codeloc)
+    if(codeloc)
+      math(EXPR _oastart "${codeloc} + 6")
+      string(SUBSTRING ${CMAKE_CUDA_FLAGS} ${_oastart} 6 OARCH)
+      set(TRIPLE "amdgcn-amd-amdhsa")
+    else()
+      # set default to volta
+      set(OARCH "sm_70")
+      set(TRIPLE "nvptx64-nvidia-cuda")
+    endif()
+  endif()
+  set(CMAKE_CUDA_FLAGS "-Wno-cuda-compat -Wno-deprecated -DCUB_USE_COOPERATIVE_GROUPS -DONNX_NAMESPACE=onnx_c2 --offload-arch=${OARCH} -DTHRUST_IGNORE_CUB_VERSION_CHECK=ON")
+  set(CMAKE_CXX_FLAGS "-O3 -DCUB_USE_COOPERATIVE_GROUPS -DONNX_NAMESPACE=onnx_c2 -DTHRUST_IGNORE_CUB_VERSION_CHECK=ON")
+  list(APPEND TORCH_LIBRARIES ${FBGEMM_LLVM_DIR}/lib/libomp.so)
+  if(FBGEMM_OMP_TARGET)
+    list(APPEND TORCH_LIBRARIES ${FBGEMM_LLVM_DIR}/lib/libomptarget.so)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FBGEMM_OMP_TARGET")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -D_FBGEMM_OMP_TARGET")
+  endif()
+endif()
 
 set(FBGEMM ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(THIRDPARTY ${FBGEMM}/third_party)
@@ -48,13 +104,39 @@ endif()
 # gen_embedding_forward_quantized_split_[un]weighted_codegen_cuda.cu
 #
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(TORCH_CUDA_OPTIONS
+    -D__CUDA_NO_HALF_OPERATORS__
+    -D__CUDA_NO_BFLOAT16_CONVERSIONS__
+    -D__CUDA_NO_HALF2_OPERATORS__)
+else()
 set(TORCH_CUDA_OPTIONS
     --expt-relaxed-constexpr
     -D__CUDA_NO_HALF_OPERATORS__
     # -D__CUDA_NO_HALF_CONVERSIONS__
     -D__CUDA_NO_BFLOAT16_CONVERSIONS__
     -D__CUDA_NO_HALF2_OPERATORS__)
+endif()
 
+# A useful detailed configuration banner
+message("${message_line}")
+if(FBGEMM_LLVM_DIR)
+message("  ==> USE CLANG COMPILER:          YES")
+message("  ==> FBGEMM_OMP_TARGET:           ${FBGEMM_OMP_TARGET}")
+message("  ==> FBGEMM_LLVM_DIR:             ${FBGEMM_LLVM_DIR}")
+else()
+message("  ==> USE CLANG COMPILER:          NO")
+endif()
+message("  ==> FBGEMM_CPU_ONLY:             ${FBGEMM_CPU_ONLY}")
+message("  ==> CMAKE_CUDA_COMPILER:         ${CMAKE_CUDA_COMPILER}")
+message("  ==> CUDA_TOOLKIT_ROOT_DIR:       ${CUDA_TOOLKIT_ROOT_DIR}")
+message("  ==> CMAKE_CUDA_COMPILER_ID:      ${CMAKE_CUDA_COMPILER_ID}")
+message("  ==> CMAKE_CUDA_COMPILER_VERSION: ${CMAKE_CUDA_COMPILER_VERSION}")
+message("  ==> CMAKE_CUDA_FLAGS:            ${CMAKE_CUDA_FLAGS}")
+message("  ==> CMAKE_CXX_FLAGS:             ${CMAKE_CXX_FLAGS}")
+message("  ==> TORCH_CUDA_OPTIONS:          ${TORCH_CUDA_OPTIONS}")
+message("  ==> TORCH_LIBRARIES:             ${TORCH_LIBRARIES}")
+message("${message_line}")
 #
 # GENERATED CUDA, CPP and Python code
 #
@@ -301,6 +383,7 @@ if(NOT FBGEMM_CPU_ONLY)
     PROPERTIES INCLUDE_DIRECTORIES "${cpp_fbgemm_files_include_directories}")
 endif()
 
+
 set_source_files_properties(
   ${fbgemm_gpu_sources_cpu}
   PROPERTIES INCLUDE_DIRECTORIES "${cpp_fbgemm_files_include_directories}")
@@ -309,6 +392,19 @@ if(NOT FBGEMM_CPU_ONLY)
   set(fbgemm_gpu_sources ${fbgemm_gpu_sources_gpu} ${fbgemm_gpu_sources_cpu})
 else()
   set(fbgemm_gpu_sources ${fbgemm_gpu_sources_cpu})
+endif()
+
+if(FBGEMM_OMP_TARGET)
+  # Compile files ending in _omp.cpp with omp target offload.
+  set(fbgemm_gpu_sources_omp src/sparse_ops_omp.cpp)
+  set_source_files_properties(${fbgemm_gpu_sources_omp}
+    PROPERTIES COMPILE_OPTIONS
+    "-fopenmp;-fopenmp-targets=${TRIPLE};-Xopenmp-target=${TRIPLE};-march=${OARCH}")
+  list(PREPEND cpp_fbgemm_files_include_directories ${FBGEMM_LLVM_DIR}/include)
+  set_source_files_properties(
+    ${fbgemm_gpu_sources_omp}
+    PROPERTIES INCLUDE_DIRECTORIES "${cpp_fbgemm_files_include_directories}")
+  set(fbgemm_gpu_sources ${fbgemm_gpu_sources_omp} ${fbgemm_gpu_sources})
 endif()
 
 #
@@ -330,6 +426,13 @@ if(NVML_LIB_PATH)
 endif()
 target_include_directories(fbgemm_gpu_py PRIVATE ${TORCH_INCLUDE_DIRS})
 set_property(TARGET fbgemm_gpu_py PROPERTY CXX_STANDARD 17)
+
+if(FBGEMM_LLVM_DIR)
+  if(FBGEMM_OMP_TARGET)
+    target_link_options(fbgemm_gpu_py PRIVATE -fopenmp -fopenmp-targets=${TRIPLE}
+	    -Xopenmp-target=${TRIPLE} -march=${OARCH} -L${FBGEMM_LLVM_DIR}/lib )
+  endif()
+endif()
 
 install(TARGETS fbgemm_gpu_py DESTINATION fbgemm_gpu)
 

--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -359,7 +359,9 @@ Tensor uvm_to_cpu_clone(Tensor t) {
 
 #ifndef __HIP_PLATFORM_HCC__
 // FIXME: some advanced "cudaMemAdvise" flags are not supported by HIP.
+#ifndef __clang__
 FBGEMM_GPU_ENUM_GLOGAL(uvm)
+#endif
 
 FBGEMM_GPU_ENUM_REGISTER_START(uvm, cudaMemoryAdvise){
     FBGEMM_GPU_ENUM_ITEM(cudaMemAdviseSetReadMostly),

--- a/fbgemm_gpu/src/cumem_utils.h
+++ b/fbgemm_gpu/src/cumem_utils.h
@@ -49,7 +49,9 @@ void uvm_mem_advice_dont_fork(Tensor t);
 // Copy a contigious uvm Tensor (uvm_storage(t) is true) into a CPU Tensor
 // The copy uses single threaded memcpy
 Tensor uvm_to_cpu_clone(Tensor t);
-
+#if defined(__clang__) && defined(__device__)
+FBGEMM_GPU_ENUM_GLOGAL(uvm)
+#endif
 FBGEMM_GPU_ENUM_CREATE_TAG(uvm)
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -1472,6 +1472,7 @@ bucketize_sparse_features_cuda(
   return {new_lengths, new_indices, new_weights, new_pos};
 }
 
+#if !defined(_FBGEMM_OMP_TARGET)
 template <typename Dtype>
 __global__
 __launch_bounds__(kMaxThreads) void reorder_batched_ad_lengths_kernel(
@@ -1648,6 +1649,7 @@ Tensor reorder_batched_ad_indices_gpu(
       });
   return reordered_cat_ad_indices;
 }
+#endif
 
 // Forward kernel for batched unary embedding op
 template <typename scalar_t, typename index_t>

--- a/fbgemm_gpu/src/sparse_ops_omp.cpp
+++ b/fbgemm_gpu/src/sparse_ops_omp.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2022 AMD
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// This source file is an example of how to replace cuda kernels with OpenMP
+// target offload functions. Please read the comment blocks below for
+// more information on how this is done.
+
+#include <omp.h>
+
+#ifdef __CUDA__
+#error Only for OpenMP.   Cannot compile this source with a CUDA compiler
+#endif
+
+// Carefully add necessary headers here. By convention, Source files, like
+// this, ending in "_omp.cpp" go through host and device passes of the
+// OpenMP target offload compiler. Some pytorch headers expect certain
+// compile conditions on the device pass. For processing those headers,
+// we temporarily fake a cuda or hip compiler by setting certain macros.
+// Like the CUDA and HIP compilers, the OpenMP clang compiler sets macro
+// __CUDA_ARCH__ ONLY during the device pass. So we test that macro to
+// setup the fake environment. We do not want to do this on the host pass.
+#ifdef __CUDA_ARCH__
+#pragma push_macro("__CUDACC__")
+#pragma push_macro("__device__")
+#pragma push_macro("__host__")
+#define __FAKING_CUDA_HIP_ENV__
+#if defined(__NVPTX__)
+#define __CUDACC__
+#include <vector_functions.h>
+#endif
+#if defined(__AMDGCN__)
+#define __HIPCC__
+#endif
+// #define __CUDA__ maybe we need to set __CUDA__
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
+#define C10_USING_CUSTOM_GENERATED_MACROS
+#endif
+
+#include "fbgemm_gpu/sparse_ops_utils.h"
+#include <ATen/CPUFunctions.h>
+
+#if defined(__FAKING_CUDA_HIP_ENV__)
+#undef __FAKING_CUDA_HIP_ENV__
+#pragma pop_macro("__CUDACC__")
+#pragma pop_macro("__device__")
+#pragma pop_macro("__host__")
+#endif
+
+using Tensor = at::Tensor;
+
+namespace fbgemm_gpu {
+
+// This OpenMP target offload kernel is nearly the same as the cpu source
+// reorder_batched_ad_lengths_ function with the exception of the added
+// OpenMP target pragma and the manual loop collapse. Instead of OpenMP
+// target maps, we use is_device_ptr because cuda manages all the device data.
+template <typename index_t, typename scalar_t>
+void reorder_batched_ad_lengths_omp(const Tensor &cat_ad_lengths,
+                                    const Tensor &batch_offsets,
+                                    const int64_t num_ads_in_batch,
+                                    Tensor &output) {
+  const int64_t nB = batch_offsets.numel() - 1;
+  const int64_t nT = cat_ad_lengths.numel() / num_ads_in_batch;
+  const auto *batch_offsets_data = batch_offsets.data_ptr<index_t>();
+  const auto *cat_ad_lengths_data = cat_ad_lengths.data_ptr<scalar_t>();
+  auto *output_data = output.data_ptr<scalar_t>();
+#pragma omp target teams distribute parallel for is_device_ptr(                \
+    cat_ad_lengths_data, batch_offsets_data, output_data)
+  for (auto k = 0; k < nB * nT; k++) {
+    auto b = k / nT;
+    auto t = k % nT;
+    const auto num_ads_b = batch_offsets_data[b + 1] - batch_offsets_data[b];
+    const int32_t input_segment_start =
+        nT * batch_offsets_data[b] + t * num_ads_b;
+    const int32_t output_segment_start =
+        t * num_ads_in_batch + batch_offsets_data[b];
+    for (auto i = 0; i < num_ads_b; i++) {
+      output_data[output_segment_start + i] =
+          cat_ad_lengths_data[input_segment_start + i];
+    }
+  }
+}
+
+// The omp wrapper function must have the same name and interface as the _gpu
+// wrapper functions found in sparse_ops.cu. To avoid duplicate names, the _gpu
+// functions in the .cu file are ifdef'd out with ifndef _FBGEMM_OMP_TARGET.
+// This _omp.cpp file is only compiled with --omp_target. See CMakeLists.txt.
+// The device data checks are also the same because CUDA is managing all the
+// device data. However the DISPATCH is to the omp function above.
+Tensor reorder_batched_ad_lengths_gpu(const Tensor &cat_ad_lengths,
+                                      const Tensor &batch_offsets,
+                                      const int64_t num_ads_in_batch) {
+  /* These from .cu */
+  TENSOR_ON_CUDA_GPU(cat_ad_lengths);
+  TENSOR_ON_CUDA_GPU(batch_offsets);
+  TENSORS_ON_SAME_DEVICE(cat_ad_lengths, batch_offsets);
+
+  Tensor reordered_cat_ad_lengths = at::empty_like(cat_ad_lengths);
+  AT_DISPATCH_INDEX_TYPES(
+      batch_offsets.scalar_type(), "reorder_batched_ad_lengths_gpu_kernel1",
+      [&] {
+        AT_DISPATCH_ALL_TYPES(
+            cat_ad_lengths.scalar_type(),
+            "reorder_batched_ad_lengths_gpu_kernel2", [&] {
+              reorder_batched_ad_lengths_omp<index_t, scalar_t>(
+                  cat_ad_lengths, batch_offsets, num_ads_in_batch,
+                  reordered_cat_ad_lengths);
+            });
+      });
+  return reordered_cat_ad_lengths;
+}
+
+template <typename index_t, typename scalar_t>
+void reorder_batched_ad_indices_omp(const Tensor &cat_ad_offsets,
+                                    const Tensor &cat_ad_indices,
+                                    const Tensor &reordered_cat_ad_offsets,
+                                    const Tensor &batch_offsets,
+                                    const int64_t num_ads_in_batch,
+                                    Tensor &output) {
+  const int64_t nB = batch_offsets.numel() - 1;
+  const int64_t nT = (cat_ad_offsets.numel() - 1) / num_ads_in_batch;
+  const auto *batch_offsets_data = batch_offsets.data_ptr<int32_t>();
+  const auto *cat_ad_offsets_data = cat_ad_offsets.data_ptr<index_t>();
+  const auto *reordered_cat_ad_offsets_data =
+      reordered_cat_ad_offsets.data_ptr<index_t>();
+  const auto *cat_ad_indices_data = cat_ad_indices.data_ptr<scalar_t>();
+  auto *output_data = output.data_ptr<scalar_t>();
+
+#pragma omp target teams distribute parallel for is_device_ptr(                \
+    batch_offsets_data, cat_ad_offsets_data, reordered_cat_ad_offsets_data,    \
+    cat_ad_indices_data, output_data)
+  for (auto k = 0; k < nB * nT; k++) {
+    auto b = k / nT;
+    auto t = k % nT;
+    const auto num_ads_b = batch_offsets_data[b + 1] - batch_offsets_data[b];
+    const int32_t input_segment_offset_start =
+        nT * batch_offsets_data[b] + t * num_ads_b;
+    const int32_t input_segment_offset_end =
+        nT * batch_offsets_data[b] + t * num_ads_b + num_ads_b;
+
+    const auto input_segment_start =
+        cat_ad_offsets_data[input_segment_offset_start];
+    const auto input_segment_end =
+        cat_ad_offsets_data[input_segment_offset_end];
+
+    const auto output_segment_offset_start =
+        t * num_ads_in_batch + batch_offsets_data[b];
+    const auto output_segment_start =
+        reordered_cat_ad_offsets_data[output_segment_offset_start];
+
+    for (auto i = 0; i < input_segment_end - input_segment_start; i++) {
+      output_data[output_segment_start + i] =
+          cat_ad_indices_data[input_segment_start + i];
+    }
+  }
+}
+
+// Must be same name and interface found in sparse_ops.cu
+Tensor reorder_batched_ad_indices_gpu(const Tensor &cat_ad_offsets,
+                                      const Tensor &cat_ad_indices,
+                                      const Tensor &reordered_cat_ad_offsets,
+                                      const Tensor &batch_offsets,
+                                      const int64_t num_ads_in_batch) {
+  TENSOR_ON_CUDA_GPU(cat_ad_offsets);
+  TENSOR_ON_CUDA_GPU(cat_ad_indices);
+  TENSOR_ON_CUDA_GPU(reordered_cat_ad_offsets);
+  TENSOR_ON_CUDA_GPU(batch_offsets);
+  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, cat_ad_indices);
+  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, reordered_cat_ad_offsets);
+  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, batch_offsets);
+
+  Tensor reordered_cat_ad_indices = at::empty_like(cat_ad_indices);
+  AT_DISPATCH_INDEX_TYPES(
+      cat_ad_offsets.scalar_type(), "reorder_batched_ad_indices_gpu_kernel_1",
+      [&] {
+        AT_DISPATCH_ALL_TYPES(
+            cat_ad_indices.scalar_type(),
+            "reorder_batched_ad_indices_gpu_kernel_2", [&] {
+              reorder_batched_ad_indices_omp<index_t, scalar_t>(
+                  cat_ad_offsets, cat_ad_indices, reordered_cat_ad_offsets,
+                  batch_offsets, num_ads_in_batch, reordered_cat_ad_indices);
+            });
+      });
+
+  return reordered_cat_ad_indices;
+}
+
+} // end of namespace fbgemm_gpu


### PR DESCRIPTION

This PR adds support for new setup.py flags --clang and --omp_target .  These flags support clang-cuda compiler and OpenMP target offload. The --omp_target option will allow replacing cuda kernels with equivalent versions using OpenMP target offload.  The cuda environment is still active for all non-replaced cuda kernels.   Cuda still manages the device data environment so OpenMP target regions do not use map clauses.  Instead all device pointers are identified with is_device_ptr clause.  
  
Two examples of OpenMP target offload are provided to demonstrate how to use OpenMP target offload for GPU offloading.   